### PR TITLE
[Bug, AMP-2156] fix blend4j time zone conversion bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 target
 test-output
 /.classpath
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr

--- a/src/main/java/com/github/jmchilton/blend4j/BaseClient.java
+++ b/src/main/java/com/github/jmchilton/blend4j/BaseClient.java
@@ -21,6 +21,8 @@ import com.sun.jersey.multipart.BodyPart;
 import com.sun.jersey.multipart.FormDataBodyPart;
 import com.sun.jersey.multipart.FormDataMultiPart;
 import com.sun.jersey.multipart.file.FileDataBodyPart;
+import java.text.SimpleDateFormat;
+import java.util.TimeZone;
 
 /**
  * AMPPD extension
@@ -33,6 +35,9 @@ public class BaseClient {
   public BaseClient(final WebResource baseWebResource,
                     final String module) {
     this.webResource = baseWebResource.path(module);
+    SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+    dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+    this.mapper.setDateFormat(dateFormat);
   }
   
   protected ClientResponse create(final Object object) {


### PR DESCRIPTION
To fix this issue we need to set ObjectMapper timezone to be UTC as we are getting dates in that timezone. Steps taken to debug this issue:

- I noticed that json data is mapped to Dataset using ObjectMapper
- I have create separate project to check ObjectMapper
- Here is the code for my test project:

**Main Class**
```bash
public static void main(String[] args) throws IOException, ParseException{
        ObjectMapper objectMapper = new ObjectMapper();
        String json = "{\"color\" : \"black\", \"type\" : \"BMW\", \"createdAt\" : \"2022-08-15T08:21:08.494781\"}";
        SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
        df.setTimeZone(TimeZone.getTimeZone("UTC"));
        objectMapper.setDateFormat(df);
        Car car = objectMapper.readValue(json, Car.class);
        System.out.println(String.valueOf(car.getDate())); 
    }
```

**Car Class used for mapping**
```bash
@JsonIgnoreProperties(ignoreUnknown=true)
public class Car {

    @JsonProperty("color")
    private String color;
    
    @JsonProperty("type")
    private String type;
    
    @JsonProperty("createdAt")
    private Date createdAt;
    
    public Date getDate() {
        return this.createdAt;
    }
}
```

- The createdAt time in json string is what we are getting from API call so I used that for testing. 
- If you comment out following lines from code you will get wrong minutes so thats the fix for timezone issue

```bash
SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
df.setTimeZone(TimeZone.getTimeZone("UTC"));
objectMapper.setDateFormat(df);
```