### PR TITLE
[Bug, AMP-2156] fix blend4j time zone conversion bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ test-output
 *.iws
 *.iml
 *.ipr
+
+mainTest.java

--- a/src/main/java/com/github/jmchilton/blend4j/BaseClient.java
+++ b/src/main/java/com/github/jmchilton/blend4j/BaseClient.java
@@ -65,15 +65,10 @@ public class BaseClient {
 
   protected <T> List<T> get(final WebResource webResource, final TypeReference<List<T>> typeReference) {
     final String json = getJson(webResource);
-    // Start AMP Customization
-    System.out.println("Rimsha U7");
-    System.out.println(json);
-    // End AMP Customization
     return readJson(json, typeReference);
   }
 
   protected <T> List<T> get(final TypeReference<List<T>> typeReference) {
-    System.out.println("Rimsha U4");
     return get(getWebResource(), typeReference);
   }
 
@@ -191,14 +186,12 @@ public class BaseClient {
   }
   
   protected String getJson(final WebResource webResource) {
-    System.out.println("Rimsha U5");
     return getJson(webResource, true);
   }
 
   protected String getJson(final WebResource webResource, final boolean checkResponse) {
     final ClientResponse response = getResponse(webResource, checkResponse);
     final String json = response.getEntity(String.class);
-    System.out.println("Rimsha U6 ---> " + json);
     return json;
   }
 
@@ -224,7 +217,6 @@ public class BaseClient {
   }
 
   protected WebResource getWebResourceContents(final String id) {
-    System.out.println("Rimsha U3 --> " + id);
     return getWebResource(id).path("contents");
   }
   
@@ -266,7 +258,6 @@ public class BaseClient {
   }
 
   protected <T> T readJson(final String json, final TypeReference<T> typeReference) {
-    System.out.println("Rimsha U8--->" + json);
     try {
       return mapper.readValue(json, typeReference);
     } catch(IOException e) {
@@ -275,7 +266,6 @@ public class BaseClient {
   }
   
   protected <T> T readJson(final String json, final Class<T> clazz) {
-    System.out.println("Rimsha U9--->" + json);
     try {
       return mapper.readValue(json, clazz);
     } catch(IOException e) {

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/Client.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/Client.java
@@ -24,7 +24,6 @@ class Client extends BaseClient {
   }
   
   protected <T extends HasGalaxyUrl> T setGalaxyUrl(final T bean) {
-    System.out.println("Rimsha U2");
     bean.setGalaxyUrl(galaxyInstance.getGalaxyUrl());
     bean.setApiKey(galaxyInstance.getApiKey());
     return bean;

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/HistoriesClientImpl.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/HistoriesClientImpl.java
@@ -59,7 +59,6 @@ class HistoriesClientImpl extends Client implements HistoriesClient {
   }
 
   public Dataset showDataset(String historyId, String datasetId) {
-    System.out.println("Rimsha U1");
     return setGalaxyUrl(getWebResourceContents(historyId).path(datasetId).get(Dataset.class));
   }
 

--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/beans/Dataset.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/beans/Dataset.java
@@ -4,12 +4,15 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import org.codehaus.jackson.annotate.JsonIgnore;
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 import org.codehaus.jackson.annotate.JsonProperty;
 
 import com.github.jmchilton.blend4j.galaxy.beans.collection.response.ElementResponse;
 import com.github.jmchilton.blend4j.util.Objects;
+import org.codehaus.jackson.map.annotate.JsonDeserialize;
+import com.github.jmchilton.blend4j.util.CustomJsonDateDeserializer;
 
 /**
  * AMPPD extension
@@ -29,7 +32,8 @@ public class Dataset extends HistoryContents implements HasGalaxyUrl, ElementRes
 
 	private Boolean resubmitted;
 	
-	@JsonProperty("create_time")	
+	@JsonProperty("create_time")
+	@JsonDeserialize(using = CustomJsonDateDeserializer.class) // AMP Customization
 	private Date createTime;
 
 	@JsonProperty("creating_job")	
@@ -41,7 +45,8 @@ public class Dataset extends HistoryContents implements HasGalaxyUrl, ElementRes
 	@JsonProperty("hda_ldda")	
 	private String hdaLdda;			
 
-	@JsonProperty("update_time")	
+	@JsonProperty("update_time")
+	@JsonDeserialize(using = CustomJsonDateDeserializer.class) // AMP Customization
 	private Date updateTime;
 
 	private List<String> tags = new ArrayList<String>();

--- a/src/main/java/com/github/jmchilton/blend4j/util/CustomJsonDateDeserializer.java
+++ b/src/main/java/com/github/jmchilton/blend4j/util/CustomJsonDateDeserializer.java
@@ -1,0 +1,34 @@
+package com.github.jmchilton.blend4j.util;
+
+import java.text.ParseException;
+import java.util.Date;
+import org.codehaus.jackson.JsonParser;
+import org.codehaus.jackson.map.JsonDeserializer;
+import org.codehaus.jackson.map.DeserializationContext;
+import java.io.IOException;
+import org.codehaus.jackson.JsonProcessingException;
+import java.text.SimpleDateFormat;
+import java.util.TimeZone;
+
+/**
+ * AMPPD Customization for timezone
+ */
+public class CustomJsonDateDeserializer extends JsonDeserializer<Date>
+{
+    @Override
+    public Date deserialize(JsonParser jsonParser,
+                            DeserializationContext deserializationContext) throws IOException, JsonProcessingException {
+
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+        format.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        String date = jsonParser.getText();
+        try {
+            return format.parse(date);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+
+}


### PR DESCRIPTION
When [show dataset](https://github.com/AudiovisualMetadataPlatform/blend4j/blob/master/src/main/java/com/github/jmchilton/blend4j/galaxy/HistoriesClientImpl.java#L63) function calls, it is using WebResource get request for api call and pass Dataset class to get Request. Get request will map JSON response to Dataset class and give Dataset object so string to date conversion is causing issue and we need something on [create time](https://github.com/AudiovisualMetadataPlatform/blend4j/blob/master/src/main/java/com/github/jmchilton/blend4j/galaxy/beans/Dataset.java#L33) property. To fix this issue, I added JsonDeserialize and converted string to date using UTC timezone.


**NOTE:** Right now,  `JsonDeserialize` added only on `create_time` and `update_time` in Dataset. Let me know if we need to add this on any other bean object.