### PR TITLE
[Bug, AMP-2156] fix blend4j time zone conversion bug 

### DIFF
--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/beans/Dataset.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/beans/Dataset.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import org.codehaus.jackson.annotate.JsonIgnore;
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 import org.codehaus.jackson.annotate.JsonProperty;


### PR DESCRIPTION
After last code merge, I am not able to get jar file for blend4j anymore and reason could be in code compile there was an extra library included in `Dataset.java` file